### PR TITLE
Cache generated Color instances (avoid gc)

### DIFF
--- a/src/main/java/com/chrisnewland/demofx/effect/AbstractEffect.java
+++ b/src/main/java/com/chrisnewland/demofx/effect/AbstractEffect.java
@@ -35,7 +35,8 @@ public abstract class AbstractEffect implements IEffect
 	protected PreCalc precalc;
 	protected DemoConfig config;
 
-	private double colourCycleAngle = 0;
+	private int colourCycleAngle = 0;
+	private static ColourCycleCache COLOUR_CYCLE = null;
 
 	protected long effectStartMillis = -1;
 	protected long effectStopMillis = -1;
@@ -72,6 +73,9 @@ public abstract class AbstractEffect implements IEffect
 		{
 			setupOffScreen(config.getOffScreenWidth(), config.getOffScreenHeight());
 		}
+		if (COLOUR_CYCLE == null) {
+			COLOUR_CYCLE = new ColourCycleCache(precalc);
+		}
 	}
 
 	private void setupOffScreen(double newWidth, double newHeight)
@@ -104,13 +108,17 @@ public abstract class AbstractEffect implements IEffect
 
 	protected final Color getCycleColour()
 	{
+		// range [0, 360[
 		colourCycleAngle++;
 
 		if (colourCycleAngle >= 360)
 		{
 			colourCycleAngle -= 360;
 		}
+		return COLOUR_CYCLE.colors[colourCycleAngle];
+	}
 
+	static Color generateColour(PreCalc precalc, int colourCycleAngle) {
 		double redFraction = 2 + precalc.sin(colourCycleAngle);
 		double greenFraction = 2 + precalc.sin(360 - colourCycleAngle);
 		double blueFraction = 2 + precalc.cos(colourCycleAngle);
@@ -264,6 +272,16 @@ public abstract class AbstractEffect implements IEffect
 			for (int x = 0; x < imageWidth; x++)
 			{
 				dest[pixel++] = reader.getArgb(x, y);
+			}
+		}
+	}
+
+	final class ColourCycleCache {
+		final Color[] colors = new Color[360];
+        
+		ColourCycleCache(PreCalc precalc) {
+			for (int i = 0; i < 360; i++) {
+				colors[i] = generateColour(precalc, i);
 			}
 		}
 	}

--- a/src/main/java/com/chrisnewland/demofx/util/ShapeEffect.java
+++ b/src/main/java/com/chrisnewland/demofx/util/ShapeEffect.java
@@ -14,6 +14,8 @@ import javafx.scene.paint.Color;
 
 public class ShapeEffect extends AbstractEffect
 {
+	private final static int FADE_STEPS = 50;
+
 	protected double[] shapePosX;
 	protected double[] shapePosY;
 	protected double[] shapeVectorX;
@@ -26,6 +28,8 @@ public class ShapeEffect extends AbstractEffect
 	protected int[] shapeColorRed;
 	protected int[] shapeColorGreen;
 	protected int[] shapeColorBlue;
+
+	protected final Color[][] shapeFadedColors;
 
 	protected double[] shapeAngle;
 
@@ -99,6 +103,7 @@ public class ShapeEffect extends AbstractEffect
 		shapeColorRed = new int[itemCount];
 		shapeColorGreen = new int[itemCount];
 		shapeColorBlue = new int[itemCount];
+		shapeFadedColors = new Color[itemCount][FADE_STEPS + 1];
 
 		shapeAngle = new double[itemCount];
 
@@ -317,6 +322,13 @@ public class ShapeEffect extends AbstractEffect
 
 		double fadeFactor = precalc.getCoordinateFade((int) x, (int) y);
 
+		// cache colors:
+		int fadeIndex = (int)(FADE_STEPS * fadeFactor);
+		Color color = shapeFadedColors[index][fadeIndex];
+		if (color != null) {
+			return color;
+		}
+
 		r *= fadeFactor;
 		g *= fadeFactor;
 		b *= fadeFactor;
@@ -325,7 +337,9 @@ public class ShapeEffect extends AbstractEffect
 		g = Math.max(0, Math.min(g, 255));
 		b = Math.max(0, Math.min(b, 255));
 
-		return Color.rgb(r, g, b);
+		color = Color.rgb(r, g, b);
+		shapeFadedColors[index][fadeIndex] = color;
+		return color;
 	}
 
 	private final void initialiseShapeRadii()


### PR DESCRIPTION
I implemented Color caches to avoid allocating Colors within hot loops (memory waste = GC).

Few other Colors.rgb(r,g,b) cases remains unmodified.